### PR TITLE
Remove fileSize, mimeType, and fileName from StoreRequest

### DIFF
--- a/src/main/java/com/connexta/ingest/client/StoreClient.java
+++ b/src/main/java/com/connexta/ingest/client/StoreClient.java
@@ -37,8 +37,6 @@ public class StoreClient {
       @NotBlank final String fileName)
       throws StoreException {
     final MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
-    body.add("fileSize", fileSize);
-    body.add("mimeType", mimeType);
     body.add(
         "file",
         new InputStreamResource(inputStream) {
@@ -53,7 +51,6 @@ public class StoreClient {
             return fileName;
           }
         });
-    body.add("fileName", fileName);
 
     final HttpHeaders headers = new HttpHeaders();
     headers.set("Accept-Version", "0.1.0");

--- a/src/main/java/com/connexta/ingest/client/TransformClient.java
+++ b/src/main/java/com/connexta/ingest/client/TransformClient.java
@@ -8,6 +8,7 @@ package com.connexta.ingest.client;
 
 import com.connexta.ingest.exceptions.TransformException;
 import com.connexta.transformation.rest.models.TransformRequest;
+import java.net.URI;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
@@ -27,17 +28,15 @@ public class TransformClient {
   @NotBlank private final String transformApiVersion;
 
   public void requestTransform(
-      @NotNull @Min(1L) @Max(10737418240L) final Long fileSize,
+      final URI location,
       @NotBlank final String mimeType,
-      @NotBlank final String location)
+      @NotNull @Min(1L) @Max(10737418240L) final Long fileSize)
       throws TransformException {
     final HttpHeaders headers = new HttpHeaders();
     headers.set("Accept-Version", transformApiVersion);
 
-    final TransformRequest transformRequest = new TransformRequest();
-    transformRequest.setBytes(fileSize);
-    transformRequest.setMimeType(mimeType);
-    transformRequest.setLocation(location);
+    final TransformRequest transformRequest =
+        new TransformRequest().location(location.toString()).mimeType(mimeType).bytes(fileSize);
 
     final HttpEntity<TransformRequest> transformRequestHttpEntity =
         new HttpEntity<>(transformRequest, headers);

--- a/src/main/java/com/connexta/ingest/client/TransformClient.java
+++ b/src/main/java/com/connexta/ingest/client/TransformClient.java
@@ -28,7 +28,7 @@ public class TransformClient {
   @NotBlank private final String transformApiVersion;
 
   public void requestTransform(
-      final URI location,
+      @NotNull final URI location,
       @NotBlank final String mimeType,
       @NotNull @Min(1L) @Max(10737418240L) final Long fileSize)
       throws TransformException {

--- a/src/main/java/com/connexta/ingest/service/impl/IngestServiceImpl.java
+++ b/src/main/java/com/connexta/ingest/service/impl/IngestServiceImpl.java
@@ -12,6 +12,7 @@ import com.connexta.ingest.exceptions.StoreException;
 import com.connexta.ingest.exceptions.TransformException;
 import com.connexta.ingest.service.api.IngestService;
 import java.io.InputStream;
+import java.net.URI;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
@@ -33,10 +34,10 @@ public class IngestServiceImpl implements IngestService {
       @NotNull final InputStream inputStream,
       @NotBlank final String fileName)
       throws StoreException, TransformException {
-    final String location = storeClient.store(fileSize, mimeType, inputStream, fileName).toString();
+    final URI location = storeClient.store(fileSize, mimeType, inputStream, fileName);
     log.info("{} has been successfully stored and can be downloaded at {}", fileName, location);
 
-    transformClient.requestTransform(fileSize, mimeType, location);
+    transformClient.requestTransform(location, mimeType, fileSize);
     log.info("Successfully submitted a transform request for {}", fileName);
   }
 }

--- a/src/test/java/com/connexta/ingest/IngestITests.java
+++ b/src/test/java/com/connexta/ingest/IngestITests.java
@@ -86,17 +86,18 @@ public class IngestITests {
 
   @Test
   public void testSuccessfulIngestRequest() throws Exception {
-    final String location = "http://localhost:1232/store/1234";
+    final URI location = new URI("http://localhost:1232/store/1234");
     storeServer
         .expect(requestTo(endpointUrlStore))
         .andExpect(method(HttpMethod.POST))
-        .andRespond(withCreatedEntity(new URI(location)));
+        // TODO verify media type
+        .andRespond(withCreatedEntity(location));
 
     transformServer
         .expect(requestTo(endpointUrlTransform))
         .andExpect(method(HttpMethod.POST))
         .andExpect(header("Accept-Version", endpointsTransformVersion))
-        .andExpect(jsonPath("$.location").value(location))
+        .andExpect(jsonPath("$.location").value(location.toString())) // TODO assert URI, not String
         .andRespond(
             withStatus(HttpStatus.ACCEPTED)
                 .contentType(MediaType.APPLICATION_JSON)
@@ -168,17 +169,17 @@ public class IngestITests {
   // transformation endpoint.
   @Test
   public void testUnsuccessfulTransformRequest() throws Exception {
-    final String location = "http://localhost:1232/store/1234";
+    final URI location = new URI("http://localhost:1232/store/1234");
     storeServer
         .expect(requestTo(endpointUrlStore))
         .andExpect(method(HttpMethod.POST))
-        .andRespond(withCreatedEntity(new URI(location)));
+        .andRespond(withCreatedEntity(location));
 
     transformServer
         .expect(requestTo(endpointUrlTransform))
         .andExpect(method(HttpMethod.POST))
         .andExpect(header("Accept-Version", endpointsTransformVersion))
-        .andExpect(jsonPath("$.location").value(location))
+        .andExpect(jsonPath("$.location").value(location.toString())) // TODO assert URI, not String
         .andRespond(withServerError());
 
     mvc.perform(


### PR DESCRIPTION
This needs to be heroed. I'm not sure if we're correctly sending the media type in the store product request. See https://github.com/connexta/replication/blob/3bfb6c39cea5821ac13dc55389d93ec029890216/adapters/ion-adapter/src/main/java/com/connexta/replication/adapters/ion/IonNodeAdapter.java#L186-L204.