### PR TITLE
Allow compiling with java11+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,6 @@
  * https://www.gnu.org/licenses/lgpl-3.0.html
  */
 /* Build Script */
-import org.gradle.internal.jvm.Jvm
-
 buildscript {
     repositories {
         maven { url "https://plugins.gradle.org/m2/" }
@@ -53,13 +51,6 @@ dependencies {
 
 sourceCompatibility = 1.11
 targetCompatibility = 1.11
-
-if (sourceCompatibility != Jvm.current().javaVersion) {
-    throw new Exception("You need Java ${sourceCompatibility} to build and run ${project.name}.\n" +
-            "The current version installed is ${Jvm.current().javaVersion.majorVersion}.\n" +
-            "For further reading see: \n\t> " +
-            "https://github.com/connexta/ion-ingest#prerequisites")
-}
 
 test {
     useJUnitPlatform()


### PR DESCRIPTION
Remove the java version check. Compiling to java 11 should be supported by java 11,12,13,14 based on https://openjdk.java.net/jeps/182

This check is already also done by java and will print out a message like `Could not target platform: 'Java SE 11' using tool chain: 'JDK 8 (1.8)`. if the installed JDK cannot target the target version.

@emmberk @ahoffer @jhunzik