### PR TITLE
Replace mockito-core with mockito-junit-jupiter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,8 +44,8 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}"
     implementation "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"
     testCompile "org.junit.jupiter:junit-jupiter-params:5.5.2"
+    testCompile "org.mockito:mockito-junit-jupiter:3.1.0"
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.5.2"
-    testImplementation "org.mockito:mockito-core:3.1.0"
     testImplementation("org.springframework.boot:spring-boot-starter-test:${springBootVersion}") {
         exclude group: "junit", module: "junit" // excludes JUnit 4
     }

--- a/src/test/java/com/connexta/ingest/IngestITests.java
+++ b/src/test/java/com/connexta/ingest/IngestITests.java
@@ -24,7 +24,6 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Value;
@@ -34,12 +33,10 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.client.RestTemplate;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest
 @ActiveProfiles("test")
 @AutoConfigureMockMvc

--- a/src/test/java/com/connexta/ingest/controllers/IngestControllerTests.java
+++ b/src/test/java/com/connexta/ingest/controllers/IngestControllerTests.java
@@ -7,28 +7,30 @@
 package com.connexta.ingest.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doThrow;
 
 import com.connexta.ingest.service.api.IngestService;
 import java.io.IOException;
 import javax.validation.ValidationException;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.multipart.MultipartFile;
 
+@ExtendWith(MockitoExtension.class)
 public class IngestControllerTests {
 
   @Test
-  public void ingest() throws IOException {
-    IngestService service = mock(IngestService.class);
-    MultipartFile multipartFile = mock(MultipartFile.class);
-    MultipartFile metacard = mock(MultipartFile.class);
-    Mockito.doThrow(new IOException()).when(multipartFile).getInputStream();
-    IngestController controller = new IngestController(service);
+  public void ingest(
+      @Mock final MultipartFile mockFile,
+      @Mock final IngestService mockIngestService,
+      @Mock final MultipartFile mockMetacard)
+      throws Exception {
+    doThrow(IOException.class).when(mockFile).getInputStream();
+    final IngestController ingestController = new IngestController(mockIngestService);
     assertThrows(
         ValidationException.class,
-        () -> {
-          controller.ingest("nothing", multipartFile, "also nothing", metacard);
-        });
+        () -> ingestController.ingest("nothing", mockFile, "also nothing", mockMetacard));
   }
 }


### PR DESCRIPTION
`mockito-junit-jupiter` includes support for `MockitoExtension`, which can simplify tests. See https://www.baeldung.com/mockito-junit-5-extension.