### PR TITLE
Added springBootVersion Gradle property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,9 @@
  */
 /* Build Script */
 buildscript {
+    ext {
+        springBootVersion = "2.1.8.RELEASE"
+    }
     repositories {
         maven { url "https://plugins.gradle.org/m2/" }
     }
@@ -17,7 +20,7 @@ plugins {
     id "com.palantir.docker" version "0.22.1"
     id "maven"
     id "org.owasp.dependencycheck" version "5.2.2"
-    id "org.springframework.boot" version "2.1.8.RELEASE"
+    id "org.springframework.boot" version "${springBootVersion}"
     id "org.sonarqube" version "2.8"
 }
 
@@ -38,12 +41,12 @@ dependencies {
     implementation "javax.inject:javax.inject:1"
     implementation "io.springfox:springfox-swagger2:2.9.2"
     implementation "io.springfox:springfox-swagger-ui:2.9.2"
-    implementation "org.springframework.boot:spring-boot-starter-actuator:2.1.8.RELEASE"
-    implementation "org.springframework.boot:spring-boot-starter-web:2.1.8.RELEASE"
+    implementation "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}"
+    implementation "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"
     testCompile "org.junit.jupiter:junit-jupiter-params:5.5.2"
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.5.2"
     testImplementation "org.mockito:mockito-core:3.1.0"
-    testImplementation("org.springframework.boot:spring-boot-starter-test:2.1.8.RELEASE") {
+    testImplementation("org.springframework.boot:spring-boot-starter-test:${springBootVersion}") {
         exclude group: "junit", module: "junit" // excludes JUnit 4
     }
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.5.2"


### PR DESCRIPTION
Added a Gradle property to replace the multiple instances reference in the build.gradle file.
 
References:
[Gradle Docs](https://docs.gradle.org/current/userguide/writing_build_scripts.html#sec:extra_properties)
[Stack Overflow](https://stackoverflow.com/questions/38106576/how-do-i-define-a-variable-for-the-dependency-version-in-gradle)

Hero Steps:
`gradlew build`

@emmberk @jhunzik @danskoglund @figliold @ahoffer @peterhuffer 