### PR TITLE
Extract version properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,11 @@
 /* Build Script */
 buildscript {
     ext {
+        junitJupiterVersion = "5.5.2"
+        lombokVersion = "1.18.8"
         springBootVersion = "2.1.9.RELEASE"
+        springfoxSwaggerVersion = "2.9.2"
+        transformApiVersion = "0.1.2"
     }
     repositories {
         maven { url "https://plugins.gradle.org/m2/" }
@@ -33,23 +37,23 @@ repositories {
 }
 
 dependencies {
-    annotationProcessor "org.projectlombok:lombok:1.18.10"
-    compileOnly "org.projectlombok:lombok:1.18.8"
+    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
     implementation "com.connexta.ingest:ingest-api-rest-spring-stubs:0.5.0"
-    implementation "com.connexta.transformation:transformation-api-rest-spring-stubs:0.1.2"
+    implementation "com.connexta.transformation:transformation-api-rest-spring-stubs:${transformApiVersion}"
     implementation "commons-io:commons-io:2.6"
     implementation "javax.inject:javax.inject:1"
-    implementation "io.springfox:springfox-swagger2:2.9.2"
-    implementation "io.springfox:springfox-swagger-ui:2.9.2"
+    implementation "io.springfox:springfox-swagger2:${springfoxSwaggerVersion}"
+    implementation "io.springfox:springfox-swagger-ui:${springfoxSwaggerVersion}"
     implementation "org.springframework.boot:spring-boot-starter-actuator:${springBootVersion}"
     implementation "org.springframework.boot:spring-boot-starter-web:${springBootVersion}"
-    testCompile "org.junit.jupiter:junit-jupiter-params:5.5.2"
+    testCompile "org.junit.jupiter:junit-jupiter-params:${junitJupiterVersion}"
     testCompile "org.mockito:mockito-junit-jupiter:3.1.0"
-    testImplementation "org.junit.jupiter:junit-jupiter-api:5.5.2"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:${junitJupiterVersion}"
     testImplementation("org.springframework.boot:spring-boot-starter-test:${springBootVersion}") {
         exclude group: "junit", module: "junit" // excludes JUnit 4
     }
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.5.2"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${junitJupiterVersion}"
 }
 
 sourceCompatibility = 1.11
@@ -99,7 +103,7 @@ dependencyCheck {
 }
 
 processResources {
-    expand([transformApiVersion: "0.1.0"])
+    expand([transformApiVersion: "${transformApiVersion}"])
 }
 
 bootJar {


### PR DESCRIPTION
This ensures that the `Accept-Version` in the transform request is always kept in sync with the version of the Tranform API.