### PR TITLE
Add support for modified time field in the request header

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
     implementation "com.amazonaws:aws-java-sdk-s3:1.11.646"
-    implementation "com.connexta.ingest:ingest-api-rest-spring-stubs:0.5.0"
+    implementation "com.connexta.ingest:ingest-api-rest-spring-stubs:0.6.0"
     implementation "com.connexta.transformation:transformation-api-rest-spring-stubs:${transformApiVersion}"
     implementation "commons-io:commons-io:2.6"
     implementation "javax.inject:javax.inject:1"

--- a/src/main/java/com/connexta/ingest/controllers/IngestController.java
+++ b/src/main/java/com/connexta/ingest/controllers/IngestController.java
@@ -20,14 +20,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.server.ServerWebInputException;
 
 @Slf4j
 @RestController
@@ -45,7 +44,7 @@ public class IngestController implements IngestApi {
       String correlationId,
       MultipartFile metacard) {
     if (lastModified == null || lastModified.toString().isBlank()) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
+      throw new ServerWebInputException("Last-Modified is missing or blank");
     }
     String fileName = file.getOriginalFilename();
     log.info("Ingest request received fileName={}", fileName);

--- a/src/main/java/com/connexta/ingest/controllers/IngestController.java
+++ b/src/main/java/com/connexta/ingest/controllers/IngestController.java
@@ -6,6 +6,8 @@
  */
 package com.connexta.ingest.controllers;
 
+import static org.springframework.http.HttpHeaders.LAST_MODIFIED;
+
 import com.connexta.ingest.exceptions.StoreMetacardException;
 import com.connexta.ingest.rest.spring.IngestApi;
 import com.connexta.ingest.service.api.IngestService;
@@ -44,7 +46,7 @@ public class IngestController implements IngestApi {
       String correlationId,
       MultipartFile metacard) {
     if (lastModified == null || lastModified.toString().isBlank()) {
-      throw new ServerWebInputException("LAST-MODIFIED is missing or blank");
+      throw new ServerWebInputException(LAST_MODIFIED + "is missing or blank");
     }
     String fileName = file.getOriginalFilename();
     log.info("Ingest request received fileName={}", fileName);

--- a/src/main/java/com/connexta/ingest/controllers/IngestController.java
+++ b/src/main/java/com/connexta/ingest/controllers/IngestController.java
@@ -44,7 +44,7 @@ public class IngestController implements IngestApi {
       String correlationId,
       MultipartFile metacard) {
     if (lastModified == null || lastModified.toString().isBlank()) {
-      throw new ServerWebInputException("Last-Modified is missing or blank");
+      throw new ServerWebInputException("LAST-MODIFIED is missing or blank");
     }
     String fileName = file.getOriginalFilename();
     log.info("Ingest request received fileName={}", fileName);

--- a/src/main/java/com/connexta/ingest/controllers/IngestController.java
+++ b/src/main/java/com/connexta/ingest/controllers/IngestController.java
@@ -20,13 +20,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
 
 @Slf4j
 @RestController
@@ -39,11 +40,13 @@ public class IngestController implements IngestApi {
   @Override
   public ResponseEntity<Void> ingest(
       String acceptVersion,
-      @RequestHeader(name = "Last-Modified") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-          OffsetDateTime lastModified,
+      @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime lastModified,
       MultipartFile file,
       String correlationId,
       MultipartFile metacard) {
+    if (lastModified == null || lastModified.toString().isBlank()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
+    }
     String fileName = file.getOriginalFilename();
     log.info("Ingest request received fileName={}", fileName);
     InputStream inputStream;

--- a/src/main/java/com/connexta/ingest/controllers/IngestController.java
+++ b/src/main/java/com/connexta/ingest/controllers/IngestController.java
@@ -12,16 +12,19 @@ import com.connexta.ingest.service.api.IngestService;
 import io.swagger.annotations.ApiParam;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.OffsetDateTime;
 import javax.validation.ValidationException;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -35,7 +38,12 @@ public class IngestController implements IngestApi {
 
   @Override
   public ResponseEntity<Void> ingest(
-      String acceptVersion, MultipartFile file, String correlationId, MultipartFile metacard) {
+      String acceptVersion,
+      @RequestHeader(name = "Last-Modified") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+          OffsetDateTime lastModified,
+      MultipartFile file,
+      String correlationId,
+      MultipartFile metacard) {
     String fileName = file.getOriginalFilename();
     log.info("Ingest request received fileName={}", fileName);
     InputStream inputStream;

--- a/src/test/java/com/connexta/ingest/IngestITests.java
+++ b/src/test/java/com/connexta/ingest/IngestITests.java
@@ -244,6 +244,7 @@ public class IngestITests {
         .header(
             "Accept-Version",
             "0.5.0") // TODO inject this like we do for the transformApiVersion in TransformClient
+        .header("Last-Modified", "2017-06-11T14:32:28Z")
         .exchange()
         .expectStatus()
         .isAccepted();
@@ -277,6 +278,7 @@ public class IngestITests {
         .post()
         .uri("/ingest")
         .header("Accept-Version", "1.1.1")
+        .header("Last-Modified", "2007-07-04T09:09:09.120+00:00")
         .contentType(MediaType.MULTIPART_FORM_DATA)
         .accept(MediaType.APPLICATION_JSON)
         .syncBody(TEST_INGEST_REQUEST_BODY)
@@ -316,6 +318,7 @@ public class IngestITests {
         .post()
         .uri("/ingest")
         .header("Accept-Version", "1.1.1")
+        .header("Last-Modified", "1985-10-25T17:32:28.101+00:00")
         .contentType(MediaType.MULTIPART_FORM_DATA)
         .accept(MediaType.APPLICATION_JSON)
         .syncBody(TEST_INGEST_REQUEST_BODY)

--- a/src/test/java/com/connexta/ingest/IngestITests.java
+++ b/src/test/java/com/connexta/ingest/IngestITests.java
@@ -8,6 +8,7 @@ package com.connexta.ingest;
 
 import static com.connexta.ingest.controllers.IngestController.METACARD_MEDIA_TYPE;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.springframework.http.HttpHeaders.LAST_MODIFIED;
 import static org.springframework.test.web.client.ExpectedCount.never;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
@@ -87,6 +88,7 @@ public class IngestITests {
       };
   private static final String MINIO_ADMIN_ACCESS_KEY = "admin";
   private static final String MINIO_ADMIN_SECRET_KEY = "12345678";
+  private static final String LAST_MODIFIED_DATE = "2017-06-11T14:32:28Z";
   private static final int MINIO_PORT = 9000;
 
   @Container
@@ -244,7 +246,7 @@ public class IngestITests {
         .header(
             "Accept-Version",
             "0.5.0") // TODO inject this like we do for the transformApiVersion in TransformClient
-        .header("Last-Modified", "2017-06-11T14:32:28Z")
+        .header(LAST_MODIFIED, LAST_MODIFIED_DATE)
         .exchange()
         .expectStatus()
         .isAccepted();
@@ -278,7 +280,7 @@ public class IngestITests {
         .post()
         .uri("/ingest")
         .header("Accept-Version", "1.1.1")
-        .header("Last-Modified", "2007-07-04T09:09:09.120+00:00")
+        .header(LAST_MODIFIED, LAST_MODIFIED_DATE)
         .contentType(MediaType.MULTIPART_FORM_DATA)
         .accept(MediaType.APPLICATION_JSON)
         .syncBody(TEST_INGEST_REQUEST_BODY)
@@ -318,7 +320,7 @@ public class IngestITests {
         .post()
         .uri("/ingest")
         .header("Accept-Version", "1.1.1")
-        .header("Last-Modified", "1985-10-25T17:32:28.101+00:00")
+        .header(LAST_MODIFIED, LAST_MODIFIED_DATE)
         .contentType(MediaType.MULTIPART_FORM_DATA)
         .accept(MediaType.APPLICATION_JSON)
         .syncBody(TEST_INGEST_REQUEST_BODY)

--- a/src/test/java/com/connexta/ingest/controllers/IngestControllerTests.java
+++ b/src/test/java/com/connexta/ingest/controllers/IngestControllerTests.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.http.HttpHeaders.LAST_MODIFIED;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
@@ -41,7 +43,7 @@ public class IngestControllerTests {
 
   private static final String ACCEPT_VERSION = "0.1.0";
   private static final String CORRELATION_ID = "90210";
-  private static final String LAST_MODIFIED = "1984-04-20T08:08:08Z";
+  private static final String LAST_MODIFIED_DATE = "1984-04-20T08:08:08Z";
   private static final MockMultipartFile FILE =
       new MockMultipartFile(
           "file", "originalFilename.txt", "text/plain", "file_content".getBytes());
@@ -51,15 +53,21 @@ public class IngestControllerTests {
   @MockBean private IngestService mockIngestService;
   @Inject private MockMvc mockMvc;
 
-  @Test
-  public void testSuccessfulIngestRequest() throws Exception {
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "2017-06-11T14:32:28Z",
+        "2007-07-04T09:09:09.120+00:00",
+        "1985-10-25T17:32:28.101+00:00"
+      })
+  public void testSuccessfulIngestRequest(String lastModified) throws Exception {
     mockMvc
         .perform(
             multipart("/ingest")
                 .file(FILE)
                 .file(METACARD)
                 .param("correlationId", CORRELATION_ID)
-                .header("Last-Modified", LAST_MODIFIED)
+                .header(LAST_MODIFIED, lastModified)
                 .header("Accept-Version", ACCEPT_VERSION))
         .andExpect(status().isAccepted());
 
@@ -80,7 +88,7 @@ public class IngestControllerTests {
             multipart("/ingest")
                 .file(METACARD)
                 .param("correlationId", CORRELATION_ID)
-                .header("Last-Modified", LAST_MODIFIED)
+                .header(LAST_MODIFIED, LAST_MODIFIED_DATE)
                 .header("Accept-Version", ACCEPT_VERSION))
         .andExpect(status().isBadRequest());
 
@@ -94,7 +102,7 @@ public class IngestControllerTests {
             multipart("/ingest")
                 .file(FILE)
                 .param("correlationId", CORRELATION_ID)
-                .header("Last-Modified", LAST_MODIFIED)
+                .header(LAST_MODIFIED, LAST_MODIFIED_DATE)
                 .header("Accept-Version", ACCEPT_VERSION))
         .andExpect(status().isBadRequest());
 
@@ -108,7 +116,7 @@ public class IngestControllerTests {
             multipart("/ingest")
                 .file(FILE)
                 .file(METACARD)
-                .header("Last-Modified", LAST_MODIFIED)
+                .header(LAST_MODIFIED, LAST_MODIFIED_DATE)
                 .header("Accept-Version", ACCEPT_VERSION))
         .andExpect(status().isBadRequest());
 
@@ -119,7 +127,11 @@ public class IngestControllerTests {
   public void testMissingAcceptVersionHeader() throws Exception {
     mockMvc
         .perform(
-            multipart("/ingest").file(FILE).file(METACARD).header("Last-Modified", LAST_MODIFIED))
+            multipart("/ingest")
+                .file(FILE)
+                .file(METACARD)
+                .header(LAST_MODIFIED, LAST_MODIFIED_DATE)
+                .param("correlationId", CORRELATION_ID))
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(mockIngestService);
@@ -129,7 +141,41 @@ public class IngestControllerTests {
   public void testMissingLastModifiedHeader() throws Exception {
     mockMvc
         .perform(
-            multipart("/ingest").file(FILE).file(METACARD).header("Accept-Version", ACCEPT_VERSION))
+            multipart("/ingest")
+                .file(FILE)
+                .file(METACARD)
+                .header("Accept-Version", ACCEPT_VERSION)
+                .param("correlationId", CORRELATION_ID))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(mockIngestService);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "2011-12-03", // ISO_LOCAL_DATE
+        "2011-12-03+01:00", // ISO_OFFSET_DATE
+        "10:15:30", // ISO_LOCAL_TIME
+        "10:15:30+01:00", // ISO_OFFSET_TIME
+        "2011-12-03T10:15:30", // ISO_LOCAL_DATE_TIME
+        "2012-337", // ISO_ORDINAL_DATE
+        "2012-W48-6", // ISO_WEEK_DATE
+        "20111203", // BASIC_ISO_DATE
+        "Sun, 11 Jun 2017 14:32:28 GMT", // RFC_1123_DATE_TIME
+        "2017-06-11T14:32:28.120+0000", // ISO_DATE_TIME missing offset :
+        "             ",
+        ""
+      })
+  public void testInvalidLastModifiedHeader(String badDate) throws Exception {
+    mockMvc
+        .perform(
+            multipart("/ingest")
+                .file(FILE)
+                .file(METACARD)
+                .header("Accept-Version", ACCEPT_VERSION)
+                .header(LAST_MODIFIED, badDate)
+                .param("correlationId", CORRELATION_ID))
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(mockIngestService);
@@ -151,7 +197,7 @@ public class IngestControllerTests {
                 .file(FILE)
                 .file(METACARD)
                 .param("correlationId", CORRELATION_ID)
-                .header("Last-Modified", LAST_MODIFIED)
+                .header(LAST_MODIFIED, LAST_MODIFIED_DATE)
                 .header("Accept-Version", ACCEPT_VERSION))
         .andExpect(status().is(expectedResponseStatus.value()));
   }

--- a/src/test/java/com/connexta/ingest/controllers/IngestControllerTests.java
+++ b/src/test/java/com/connexta/ingest/controllers/IngestControllerTests.java
@@ -41,6 +41,7 @@ public class IngestControllerTests {
 
   private static final String ACCEPT_VERSION = "0.1.0";
   private static final String CORRELATION_ID = "90210";
+  private static final String LAST_MODIFIED = "1984-04-20T08:08:08Z";
   private static final MockMultipartFile FILE =
       new MockMultipartFile(
           "file", "originalFilename.txt", "text/plain", "file_content".getBytes());
@@ -58,6 +59,7 @@ public class IngestControllerTests {
                 .file(FILE)
                 .file(METACARD)
                 .param("correlationId", CORRELATION_ID)
+                .header("Last-Modified", LAST_MODIFIED)
                 .header("Accept-Version", ACCEPT_VERSION))
         .andExpect(status().isAccepted());
 
@@ -78,6 +80,7 @@ public class IngestControllerTests {
             multipart("/ingest")
                 .file(METACARD)
                 .param("correlationId", CORRELATION_ID)
+                .header("Last-Modified", LAST_MODIFIED)
                 .header("Accept-Version", ACCEPT_VERSION))
         .andExpect(status().isBadRequest());
 
@@ -91,6 +94,7 @@ public class IngestControllerTests {
             multipart("/ingest")
                 .file(FILE)
                 .param("correlationId", CORRELATION_ID)
+                .header("Last-Modified", LAST_MODIFIED)
                 .header("Accept-Version", ACCEPT_VERSION))
         .andExpect(status().isBadRequest());
 
@@ -101,7 +105,11 @@ public class IngestControllerTests {
   public void testMissingCorrelationID() throws Exception {
     mockMvc
         .perform(
-            multipart("/ingest").file(FILE).file(METACARD).header("Accept-Version", ACCEPT_VERSION))
+            multipart("/ingest")
+                .file(FILE)
+                .file(METACARD)
+                .header("Last-Modified", LAST_MODIFIED)
+                .header("Accept-Version", ACCEPT_VERSION))
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(mockIngestService);
@@ -110,7 +118,18 @@ public class IngestControllerTests {
   @Test
   public void testMissingAcceptVersionHeader() throws Exception {
     mockMvc
-        .perform(multipart("/ingest").file(FILE).file(METACARD))
+        .perform(
+            multipart("/ingest").file(FILE).file(METACARD).header("Last-Modified", LAST_MODIFIED))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(mockIngestService);
+  }
+
+  @Test
+  public void testMissingLastModifiedHeader() throws Exception {
+    mockMvc
+        .perform(
+            multipart("/ingest").file(FILE).file(METACARD).header("Accept-Version", ACCEPT_VERSION))
         .andExpect(status().isBadRequest());
 
     verifyNoInteractions(mockIngestService);
@@ -132,6 +151,7 @@ public class IngestControllerTests {
                 .file(FILE)
                 .file(METACARD)
                 .param("correlationId", CORRELATION_ID)
+                .header("Last-Modified", LAST_MODIFIED)
                 .header("Accept-Version", ACCEPT_VERSION))
         .andExpect(status().is(expectedResponseStatus.value()));
   }


### PR DESCRIPTION
Updated API version used and made adjustments based on the new version.

Annotation References:
[RequestHeader](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/bind/annotation/RequestHeader.html)
[DateTimeFormat](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/format/annotation/DateTimeFormat.html)

Hero using the README steps