### PR TITLE
Bump storeApiVersion from 0.2.0 to 0.3.0

### DIFF
--- a/src/main/java/com/connexta/ingest/client/StoreClient.java
+++ b/src/main/java/com/connexta/ingest/client/StoreClient.java
@@ -55,7 +55,7 @@ public class StoreClient {
 
     final HttpHeaders headers = new HttpHeaders();
     // TODO inject this like we do for the transformApiVersion in TransformClient
-    headers.set("Accept-Version", "0.2.0");
+    headers.set("Accept-Version", "0.3.0");
 
     final HttpEntity<MultiValueMap<String, Object>> request = new HttpEntity<>(body, headers);
     log.info("Sending POST request to {}: {}", storeEndpoint, request);


### PR DESCRIPTION
This PR is ready for review.

This version needs to be bumped to work with the current store service. I didn't address the TODO to inject the version because this will be OBE when we combine ingest and store.